### PR TITLE
Refactor NewsAPI to use /v2/everything endpoint with keyword queries

### DIFF
--- a/scripts/constants/newsConstants.js
+++ b/scripts/constants/newsConstants.js
@@ -5,41 +5,34 @@ export const NEWS_CATEGORIES = [
   {
     label: "TECNOLOGÍA",
     apiCategory: "technology",
+    query: "tecnología",
     color: "#6842ff",
     background: "#1e1444",
   },
   {
     label: "DEPORTES",
     apiCategory: "sports",
+    query: "deportes",
     color: "#00d2ff",
     background: "#003344",
   },
   {
     label: "POLÍTICA",
     apiCategory: "general",
+    query: "política",
     color: "#06d6a0",
     background: "#003320",
   },
   {
     label: "CULTURA",
     apiCategory: "entertainment",
+    query: "cultura",
     color: "#ff2d78",
     background: "#3d1428",
   },
 ];
 
-// Países soportados por NewsAPI en el endpoint top-headlines.
-// Fuente: https://newsapi.org/docs/endpoints/top-headlines
-// Nota: España (es) no está incluida; se usa "us" como fallback.
-export const SUPPORTED_COUNTRIES = new Set([
-  "ae", "ar", "at", "au", "be", "bg", "br", "ca", "ch", "cn", "co", "cu",
-  "cz", "de", "eg", "fr", "gb", "gr", "hk", "hu", "id", "ie", "il", "in",
-  "it", "jp", "kr", "lt", "lv", "ma", "mx", "my", "ng", "nl", "no", "nz",
-  "ph", "pl", "pt", "ro", "rs", "ru", "sa", "se", "sg", "si", "sk", "th",
-  "tr", "tw", "ua", "us", "ve", "za",
-]);
-
-// Idiomas soportados por NewsAPI: ar, de, en, es, fr, he, it, nl, no, pt, ru, sv, zh
+// Idiomas soportados por NewsAPI (/v2/everything): ar, de, en, es, fr, he, it, nl, no, pt, ru, sv, zh
 export const COUNTRY_LANGUAGE = {
   ae: "ar", ar: "es", at: "de", au: "en", be: "fr", br: "pt",
   ca: "en", ch: "de", cn: "zh", co: "es", cu: "es", de: "de",

--- a/scripts/constants/urls.js
+++ b/scripts/constants/urls.js
@@ -2,4 +2,4 @@ export const NOMINATIM_BASE_URL = "https://nominatim.openstreetmap.org/reverse";
 export const FLAG_BASE_URL = "https://flagcdn.com/w160";
 export const OPEN_METEO_BASE_URL = "https://api.open-meteo.com/v1/forecast";
 export const WEATHER_ICON_BASE_URL = "https://openweathermap.org/img/wn";
-export const NEWSAPI_BASE_URL = "https://newsapi.org/v2/top-headlines";
+export const NEWSAPI_BASE_URL = "https://newsapi.org/v2/everything";

--- a/scripts/service/newsService.js
+++ b/scripts/service/newsService.js
@@ -1,7 +1,7 @@
 import { fetchData } from "../helpers/fetchData.js";
 import { NEWSAPI_BASE_URL } from "../constants/urls.js";
 import { NEWS_API_KEY } from "../constants/config.js";
-import { NEWS_CATEGORIES, SUPPORTED_COUNTRIES, COUNTRY_LANGUAGE } from "../constants/newsConstants.js";
+import { NEWS_CATEGORIES, COUNTRY_LANGUAGE } from "../constants/newsConstants.js";
 
 function getRelativeTime(publishedAt) {
   const diffMs = Date.now() - new Date(publishedAt).getTime();
@@ -23,11 +23,11 @@ function mapArticle(article, category) {
   };
 }
 
-async function fetchCategory(country, language, category) {
+async function fetchCategory(language, category) {
   const params = new URLSearchParams({
-    country,
+    q: category.query,
     language,
-    category: category.apiCategory,
+    sortBy: "publishedAt",
     pageSize: "1",
     apiKey: NEWS_API_KEY,
   });
@@ -39,17 +39,15 @@ async function fetchCategory(country, language, category) {
   return article ? mapArticle(article, category) : null;
 }
 
-// Noticias filtradas por país o idioma usando NewsAPI,
-// una petición por categoría para respetar el diseño.
-// ESPAÑA NO ESTA INCLUIDO EN LOS PAÍSES SOPORTADOS POR NEWSAPI, ASÍ QUE SE USARÁ "US" COMO FALLBACK PARA ESPAÑA Y CUALQUIER OTRO PAÍS NO SOPORTADO.
+// Noticias filtradas por idioma usando el endpoint /v2/everything de NewsAPI.
+// Este endpoint no admite `country` ni `category`; se busca por palabra clave (q)
+// en el idioma derivado del país de la localización (p. ej. España → "es").
 export async function getNews(countryCode) {
   const country = (countryCode || "").toLowerCase();
-  const targetCountry = SUPPORTED_COUNTRIES.has(country) ? country : "us";
-
-  const language = COUNTRY_LANGUAGE[targetCountry] || "en";  
+  const language = COUNTRY_LANGUAGE[country] || "en";
 
   const results = await Promise.all(
-    NEWS_CATEGORIES.map((category) => fetchCategory(targetCountry, language, category)),
+    NEWS_CATEGORIES.map((category) => fetchCategory(language, category)),
   );
 
   return results.filter(Boolean);


### PR DESCRIPTION
Summary
Migrated NewsAPI from /v2/top-headlines to /v2/everything endpoint to support broader language-based filtering
Replaced country and category params with keyword queries (q) per category, enabling Spanish-language results
Removed SUPPORTED_COUNTRIES set and country fallback logic ("us") since the new endpoint filters by language derived from geolocation
Why
The /v2/top-headlines endpoint does not support Spain (es) as a country, requiring a workaround fallback to "us". The /v2/everything endpoint allows querying by keyword + language, making results relevant regardless of country support limitations.